### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,6 @@ project(afrl_driver)
 
 find_package(PkgConfig REQUIRED)
 
-include_directories(
-    include
-    ${catkin_INCLUDE_DIRS}
-)
-
 
 find_package(catkin REQUIRED COMPONENTS
     geometry_msgs
@@ -28,7 +23,10 @@ catkin_package(
     DEPENDS system_lib
 )
 
-
+include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+)
 
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
The driver doesn't compile on kinetic unless the include statement is below the find_package statement. 

With the change, it compiled correctly on Ubuntu 16.04 with kinetic.